### PR TITLE
Added ability to provide genotype field data when no GT record is present

### DIFF
--- a/vcf2tsv.py
+++ b/vcf2tsv.py
@@ -125,20 +125,20 @@ def vcf2tsv(query_vcf, out_tsv, skip_info_data, skip_genotype_data, keep_rejecte
       #dictionary, with sample names as keys, values being genotype data (dictionary with format tags as keys)
       vcf_sample_genotype_data = {}
       if len(samples) > 0 and skip_genotype_data is False:
-         if gt_present_header == 1:
-            gt_cyvcf = rec.gt_types
-            i = 0
-            while i < len(samples):
-               vcf_sample_genotype_data[samples[i]] = {}
-               gt = './.'
+         gt_cyvcf = rec.gt_types
+         i = 0
+         while i < len(samples):
+            vcf_sample_genotype_data[samples[i]] = {}
+            gt = './.'
+            if gt_present_header == 1:
                if gt_cyvcf[i] == 0:
                   gt = '0/0'
                if gt_cyvcf[i] == 1:
                   gt = '0/1'
                if gt_cyvcf[i] == 2:
                   gt = '1/1'
-               vcf_sample_genotype_data[samples[i]]['GT'] = gt
-               i = i + 1
+            vcf_sample_genotype_data[samples[i]]['GT'] = gt
+            i = i + 1
                
       for format_tag in sorted(format_columns_header):
          if len(samples) > 0 and skip_genotype_data is False:


### PR DESCRIPTION
The script currently won't output any calls if a GT field is not present and the `skip_genotype_data` flag is not set.

When making somatic calls, some callers (e.g. Strelka) don't include a GT field in the genotype data column. The genotype still contains useful sample-specific data, though.

This change will cause the script to still output the genotype data even when no GT field is present, and the GT field will consist of only "./." values.