### PR TITLE
Fixed missing values for AD column - FORMAT field

### DIFF
--- a/vcf2tsv.py
+++ b/vcf2tsv.py
@@ -202,6 +202,9 @@ def vcf2tsv(query_vcf, out_tsv, skip_info_data, skip_genotype_data, keep_rejecte
             while j < dim[0]:
                if sample_dat[j].size > 1:
                   d = ','.join(str(e) for e in np.ndarray.tolist(sample_dat[j]))
+                  ## undefined/missing value
+                  if '-2147483648' in d:
+                     d = d.replace('-2147483648', '.')
                   if samples[j] in vcf_sample_genotype_data:
                      vcf_sample_genotype_data[samples[j]][format_tag] = d
                else:


### PR DESCRIPTION
Added an if condition to check if there are any missing values represented by '-2147483648' in the AD column and replace them with a period ('.')